### PR TITLE
Update app title to "Azure Cosmos DB + Azure OpenAI"

### DIFF
--- a/src/pages/layout/Layout.tsx
+++ b/src/pages/layout/Layout.tsx
@@ -10,7 +10,7 @@ const Layout = () => {
             <header className={styles.header} role={"banner"}>
                 <div className={styles.headerContainer}>
                     <Link to="/" className={styles.headerTitleContainer}>
-                        <h3 className={styles.headerTitle}>Cosmos DB MongoDB vCore + Azure OpenAI</h3>
+                        <h3 className={styles.headerTitle}>Azure Cosmos DB + Azure OpenAI</h3>
                     </Link>
                     <nav>
                         <ul className={styles.headerNavList}>


### PR DESCRIPTION
This fixes the name of "Azure Cosmos DB" to be correct, plus removes "MongoDB" and "vCore" since this app is being used for multiple different Azure Cosmos DB developer guides.