### PR TITLE
Add support for chat session history

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Frontend: watch",
+            "type": "node-terminal",
+            "request": "launch",
+            "command": "npm run dev",
+            "cwd": "${workspaceFolder}/src",
+        }
+    ]
+}

--- a/src/api/BACKEND_URI.ts
+++ b/src/api/BACKEND_URI.ts
@@ -1,1 +1,1 @@
-export const BACKEND_URI = 'test';
+export const BACKEND_URI = 'http://localhost:4242';

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -27,7 +27,7 @@ export const getSessions = async (): Promise<{ session_id: string; title: string
     if (!response.ok) {
         if (response.status === 404) {
             console.log("FYI, API doesn't support Chat Session functionality.")
-            return [];
+            return null;
         }
         throw new Error(`Failed to fetch sessions: ${response.statusText}`);
     }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -41,10 +41,6 @@ export const getSessionHistory = async (sessionId: string): Promise<{ history: {
             headers: { "Content-Type": "application/json" }
         });
 
-        if (response.status === 404) {
-            return { history: [] };
-        }
-
         if (!response.ok) {
             throw new Error(`Failed to fetch session history: ${response.statusText}`);
         }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -26,7 +26,7 @@ export const getSessions = async (): Promise<{ session_id: string; title: string
     const response = await fetch(`${BACKEND_URI}/session/list`); // Update this to match your API endpoint
     if (!response.ok) {
         if (response.status === 404) {
-            console.log("API doesn't support Chat Session functionality.")
+            console.log("FYI, API doesn't support Chat Session functionality.")
             return [];
         }
         throw new Error(`Failed to fetch sessions: ${response.statusText}`);

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -21,3 +21,29 @@ export async function chatApi(request: ChatAppRequest): Promise<Response> {
 export function getCitationFilePath(citation: string): string {
     return `${BACKEND_URI}/content/${citation}`;
 }
+
+export const getSessions = async (): Promise<{ sessions: { session_id: string; title: string }[] }> => {
+    const response = await fetch(`${BACKEND_URI}/sessions`); // Update this to match your API endpoint
+    if (!response.ok) {
+        throw new Error(`Failed to fetch sessions: ${response.statusText}`);
+    }
+    return response.json();
+};
+
+export const getSessionHistory = async (sessionId: string): Promise<{ chat_history: { role: string; content: string }[] }> => {
+    const response = await fetch(`${BACKEND_URI}/sessions/load`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sessionId })
+    });
+
+    if (response.status === 404) {
+        return { chat_history: [] };
+    }
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch session history: ${response.statusText}`);
+    }
+
+    return response.json();
+};

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -25,6 +25,10 @@ export function getCitationFilePath(citation: string): string {
 export const getSessions = async (): Promise<{ session_id: string; title: string }[]> => {
     const response = await fetch(`${BACKEND_URI}/session/list`); // Update this to match your API endpoint
     if (!response.ok) {
+        if (response.status === 404) {
+            console.log("API doesn't support Chat Session functionality.")
+            return [];
+        }
         throw new Error(`Failed to fetch sessions: ${response.statusText}`);
     }
     return response.json();
@@ -47,5 +51,5 @@ export const getSessionHistory = async (sessionId: string): Promise<{ history: {
 
         return response.json();
     }
-    return { chat_history: [] };
+    return { history: [] };
 };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -22,28 +22,30 @@ export function getCitationFilePath(citation: string): string {
     return `${BACKEND_URI}/content/${citation}`;
 }
 
-export const getSessions = async (): Promise<{ sessions: { session_id: string; title: string }[] }> => {
-    const response = await fetch(`${BACKEND_URI}/sessions`); // Update this to match your API endpoint
+export const getSessions = async (): Promise<{ session_id: string; title: string }[]> => {
+    const response = await fetch(`${BACKEND_URI}/session/list`); // Update this to match your API endpoint
     if (!response.ok) {
         throw new Error(`Failed to fetch sessions: ${response.statusText}`);
     }
     return response.json();
 };
 
-export const getSessionHistory = async (sessionId: string): Promise<{ chat_history: { role: string; content: string }[] }> => {
-    const response = await fetch(`${BACKEND_URI}/sessions/load`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ session_id: sessionId })
-    });
+export const getSessionHistory = async (sessionId: string): Promise<{ history: { role: string; content: string }[] }> => {
+    if (sessionId && sessionId != "1234") {
+        const response = await fetch(`${BACKEND_URI}/session/load/${sessionId}`, {
+            method: "GET",
+            headers: { "Content-Type": "application/json" }
+        });
 
-    if (response.status === 404) {
-        return { chat_history: [] };
+        if (response.status === 404) {
+            return { history: [] };
+        }
+
+        if (!response.ok) {
+            throw new Error(`Failed to fetch session history: ${response.statusText}`);
+        }
+
+        return response.json();
     }
-
-    if (!response.ok) {
-        throw new Error(`Failed to fetch session history: ${response.statusText}`);
-    }
-
-    return response.json();
+    return { chat_history: [] };
 };

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -65,6 +65,7 @@ export type ChatAppResponseOrError = {
 
 export type ChatAppResponse = {
     message: string;
+    session_id: string | null;
 };
 
 export type ChatAppRequestContext = {

--- a/src/components/ClearChatButton/ClearChatButton.tsx
+++ b/src/components/ClearChatButton/ClearChatButton.tsx
@@ -1,4 +1,4 @@
-import { Delete24Regular } from "@fluentui/react-icons";
+import { AddSquare24Regular } from "@fluentui/react-icons";
 import { Button } from "@fluentui/react-components";
 
 import styles from "./ClearChatButton.module.css";
@@ -12,8 +12,8 @@ interface Props {
 export const ClearChatButton = ({ className, disabled, onClick }: Props) => {
     return (
         <div className={`${styles.container} ${className ?? ""}`}>
-            <Button icon={<Delete24Regular />} disabled={disabled} onClick={onClick}>
-                {"Clear chat"}
+            <Button icon={<AddSquare24Regular />} disabled={disabled} onClick={onClick}>
+                {"New chat"}
             </Button>
         </div>
     );

--- a/src/pages/chat/Chat.module.css
+++ b/src/pages/chat/Chat.module.css
@@ -11,7 +11,7 @@
 }
 
 .chatContainer {
-    flex: 2;
+    flex: 4;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -27,6 +27,13 @@
     flex-direction: column;
     width: 15%;
     padding: 1em;
+}
+.chatSessionContainer ul {
+    list-style-type: none;
+    padding: 0;
+}
+.chatSessionContainer ul li {
+    margin-bottom: 1em;
 }
 
 .chatEmptyState {

--- a/src/pages/chat/Chat.module.css
+++ b/src/pages/chat/Chat.module.css
@@ -36,6 +36,10 @@
     margin-bottom: 1em;
 }
 
+.chatSessionContainer ul li span {
+    font-weight: 600;
+}
+
 .chatEmptyState {
     flex-grow: 1;
     display: flex;

--- a/src/pages/chat/Chat.module.css
+++ b/src/pages/chat/Chat.module.css
@@ -6,16 +6,27 @@
 }
 
 .chatRoot {
-    flex: 1;
+    flex: 2;
     display: flex;
 }
 
 .chatContainer {
-    flex: 1;
+    flex: 2;
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 100%;
+    width: 85%;
+}
+
+.chatSessionContainer {
+    background: #f2f2f2;
+    color: #222222;
+    border-right: solid 0.1em #858585;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    width: 15%;
+    padding: 1em;
 }
 
 .chatEmptyState {

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -106,8 +106,8 @@ const Chat = () => {
     const loadSessions = async () => {
         try {
             const sessionsResponse = await getSessions(); // Call the getSessions API function
-            setSessions(sessionsResponse.sessions);
-            setHasSessions(sessionsResponse.sessions.length > 0); // Update state based on whether sessions exist
+            setSessions(sessionsResponse);
+            setHasSessions(sessionsResponse && sessionsResponse.length > 0); // Update state based on whether sessions exist
         } catch (err) {
             console.error("Failed to load sessions:", err);
             setHasSessions(false); // Update state to indicate that no sessions are available
@@ -120,9 +120,19 @@ const Chat = () => {
     }, []);
 
     useEffect(() => {
-        if (sessionId) {
-            getSessionHistory(sessionId);
-        }
+        const fetchSessionHistory = async () => {
+            if (sessionId) {
+                setIsStreaming(false);
+                setIsLoading(true);
+                const session = await getSessionHistory(sessionId);
+                const sessionAnswers: [string, ChatAppResponse][] = session.history.map((chat) => [chat.role, { message: chat.content, session_id: sessionId } as ChatAppResponse]);
+                console.log(sessionAnswers);    
+                setAnswers(sessionAnswers);
+                setIsLoading(false);
+            }
+        };
+
+        fetchSessionHistory();
     }, [sessionId]);
 
     const clearChat = () => {

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -105,6 +105,7 @@ const Chat = () => {
         setAnswers([]);
         setIsLoading(false);
         setIsStreaming(false);
+        setSessionId("1234");
     };
 
     useEffect(() => chatMessageStreamEnd.current?.scrollIntoView({ behavior: "smooth" }), [isLoading]);

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -52,6 +52,8 @@ const Chat = () => {
     const [answers, setAnswers] = useState<[user: string, response: ChatAppResponse][]>([]);
     const [showGPT4VOptions, setShowGPT4VOptions] = useState<boolean>(false);
 
+    const [sessionId, setSessionId] = useState<string>("1234");
+
     const makeApiRequest = async (question: string) => {
         lastQuestionRef.current = question;
 
@@ -62,7 +64,7 @@ const Chat = () => {
         try {
             const request: ChatAppRequest = {
                 prompt: question,
-                session_id: "1234" // TODO: Need to generate a session id
+                session_id: sessionId
             };
 
             const response = await chatApi(request);
@@ -75,6 +77,7 @@ const Chat = () => {
                 setError(bodyText);
             } else {
                 const parsedResponse: ChatAppResponse = await response.json();
+                setSessionId(parsedResponse.session_id || sessionId);
                 setAnswers([...answers, [question, parsedResponse]]);
             }
             // if (shouldStream) {

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -130,22 +130,26 @@ const Chat = () => {
                 setIsLoading(true);
                 setActiveCitation(undefined);
 
-                const session = await getSessionHistory(sessionId);
-                
-                var answerHistory = [];
-                if (session.history) {
-                    for (var i = 0; i < session.history.length; i = i + 2) {
-                        if (i < session.history.length - 1) {
-                            const question = '' + session.history[i].content;
-                            const response = '' + session.history[i + 1].content;
-                            answerHistory.push([question, { message: response, session_id: sessionId } as ChatAppResponse]);
+                try {
+                    const session = await getSessionHistory(sessionId);
+                    
+                    var answerHistory = [];
+                    if (session.history) {
+                        for (var i = 0; i < session.history.length; i = i + 2) {
+                            if (i < session.history.length - 1) {
+                                const question = '' + session.history[i].content;
+                                const response = '' + session.history[i + 1].content;
+                                answerHistory.push([question, { message: response, session_id: sessionId } as ChatAppResponse]);
+                            }
                         }
                     }
-                }
 
-                setSessionId(sessionId);
-                setAnswers(answerHistory);
-                
+                    setSessionId(sessionId);
+                    setAnswers(answerHistory);
+                } catch(e) {
+                    // Chat Session History functionality is not supported by the API
+                }
+             
                 setIsLoading(false);
 
                 lastQuestionRef.current = session.history[session.history.length - 1].content; //sessionAnswers[sessionAnswers.length - 1][1].message;

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -132,27 +132,28 @@ const Chat = () => {
 
                 try {
                     const session = await getSessionHistory(sessionId);
-                    
-                    var answerHistory = [];
-                    if (session.history) {
-                        for (var i = 0; i < session.history.length; i = i + 2) {
-                            if (i < session.history.length - 1) {
-                                const question = '' + session.history[i].content;
-                                const response = '' + session.history[i + 1].content;
-                                answerHistory.push([question, { message: response, session_id: sessionId } as ChatAppResponse]);
+                    if(session) {
+                        var answerHistory: [string, ChatAppResponse][] = [];
+                        if (session.history) {
+                            for (var i = 0; i < session.history.length; i = i + 2) {
+                                if (i < session.history.length - 1) {
+                                    const question = '' + session.history[i].content;
+                                    const response = '' + session.history[i + 1].content;
+                                    answerHistory.push([question, { message: response, session_id: sessionId } as ChatAppResponse]);
+                                }
                             }
+                            
+                            lastQuestionRef.current = session.history[session.history.length - 1].content; //sessionAnswers[sessionAnswers.length - 1][1].message;
                         }
-                    }
 
-                    setSessionId(sessionId);
-                    setAnswers(answerHistory);
+                        setSessionId(sessionId);
+                        setAnswers(answerHistory);
+                    }
                 } catch(e) {
-                    // Chat Session History functionality is not supported by the API
+                    // FYI, Chat Session History functionality is not supported by the API
                 }
              
                 setIsLoading(false);
-
-                lastQuestionRef.current = session.history[session.history.length - 1].content; //sessionAnswers[sessionAnswers.length - 1][1].message;
             }
         };
 

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -142,7 +142,7 @@ const Chat = () => {
                                     answerHistory.push([question, { message: response, session_id: sessionId } as ChatAppResponse]);
                                 }
                             }
-                            
+
                             lastQuestionRef.current = session.history[session.history.length - 1].content; //sessionAnswers[sessionAnswers.length - 1][1].message;
                         }
 
@@ -238,7 +238,11 @@ const Chat = () => {
                     <ul>
                         {sessions.map((session) => (
                             <li key={session.session_id}>
+                                {session.session_id !== sessionId ? (
                                 <a href="#" onClick={() => setSessionId(session.session_id)}>{session.title}</a>
+                                ) : (
+                                <span>{session.title}</span>
+                                )}
                             </li>
                         ))}
                     </ul>

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -107,10 +107,10 @@ const Chat = () => {
         try {
             const sessionsResponse = await getSessions(); // Call the getSessions API function
             setSessions(sessionsResponse);
-            setHasSessions(sessionsResponse && sessionsResponse.length > 0); // Update state based on whether sessions exist
+            setHasSessions(true);
         } catch (err) {
-            console.log("Failed to load sessions:", err);
-            setHasSessions(false); // Update state to indicate that no sessions are available
+            console.log("Failed to load sessions");
+            setHasSessions(false);
         }
         setIsLoading
     };
@@ -232,14 +232,17 @@ const Chat = () => {
             
             <div className={styles.chatRoot}>
                 {/* Render chat session container only if there are sessions to display */}
-                {hasSessions && (
+                {hasSessions && sessions && (
                 <div className={styles.chatSessionContainer}>
-                    <h3>Previous Sessions</h3>
+                    <h3>Chat Sessions</h3>
                     <ul>
-                        {sessions.map((session) => (
+                        {sessions && sessions.length === 0 && (
+                            <i>No chat history yet.</i>
+                        )}
+                        {sessions && sessions.map((session) => (
                             <li key={session.session_id}>
                                 {session.session_id !== sessionId ? (
-                                <a href="#" onClick={() => setSessionId(session.session_id)}>{session.title}</a>
+                                <a href="#" onClick={() => { setSessionId(session.session_id) }}>{session.title}</a>
                                 ) : (
                                 <span>{session.title}</span>
                                 )}

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -112,12 +112,16 @@ const Chat = () => {
             console.error("Failed to load sessions:", err);
             setHasSessions(false); // Update state to indicate that no sessions are available
         }
+        setIsLoading
     };
 
     // Load sessions when component mounts
     useEffect(() => {
         loadSessions();
     }, []);
+    useEffect(() => {
+        loadSessions();
+    }, [answers]);
 
     useEffect(() => {
         const fetchSessionHistory = async () => {
@@ -127,11 +131,22 @@ const Chat = () => {
                 setActiveCitation(undefined);
 
                 const session = await getSessionHistory(sessionId);
-                const sessionAnswers: [string, ChatAppResponse][] = session.history.map((chat) => [chat.role, { message: chat.content, session_id: sessionId } as ChatAppResponse]);
                 
+                var answerHistory = [];
+                for (var i = 0; i < session.history.length; i = i + 2) {
+                    if (i < session.history.length - 1) {
+                        const question = '' + session.history[i].content;
+                        const response = '' + session.history[i + 1].content;
+                        answerHistory.push([question, { message: response, session_id: sessionId } as ChatAppResponse]);
+                    }
+                }
+
                 setSessionId(sessionId);
-                setAnswers(sessionAnswers);
+                setAnswers(answerHistory);
+                
                 setIsLoading(false);
+
+                lastQuestionRef.current = session.history[session.history.length - 1].content; //sessionAnswers[sessionAnswers.length - 1][1].message;
             }
         };
 
@@ -216,11 +231,7 @@ const Chat = () => {
                     <ul>
                         {sessions.map((session) => (
                             <li key={session.session_id}>
-                                <span>{session.title}</span>
-                                <DefaultButton
-                                    text="Load Session"
-                                    onClick={() => setSessionId(session.session_id)}
-                                />
+                                <a href="#" onClick={() => setSessionId(session.session_id)}>{session.title}</a>
                             </li>
                         ))}
                     </ul>

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -122,11 +122,14 @@ const Chat = () => {
     useEffect(() => {
         const fetchSessionHistory = async () => {
             if (sessionId) {
-                setIsStreaming(false);
+                error && setError(undefined);
                 setIsLoading(true);
+                setActiveCitation(undefined);
+
                 const session = await getSessionHistory(sessionId);
                 const sessionAnswers: [string, ChatAppResponse][] = session.history.map((chat) => [chat.role, { message: chat.content, session_id: sessionId } as ChatAppResponse]);
-                console.log(sessionAnswers);    
+                
+                setSessionId(sessionId);
                 setAnswers(sessionAnswers);
                 setIsLoading(false);
             }

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -109,7 +109,7 @@ const Chat = () => {
             setSessions(sessionsResponse);
             setHasSessions(sessionsResponse && sessionsResponse.length > 0); // Update state based on whether sessions exist
         } catch (err) {
-            console.error("Failed to load sessions:", err);
+            console.log("Failed to load sessions:", err);
             setHasSessions(false); // Update state to indicate that no sessions are available
         }
         setIsLoading
@@ -133,11 +133,13 @@ const Chat = () => {
                 const session = await getSessionHistory(sessionId);
                 
                 var answerHistory = [];
-                for (var i = 0; i < session.history.length; i = i + 2) {
-                    if (i < session.history.length - 1) {
-                        const question = '' + session.history[i].content;
-                        const response = '' + session.history[i + 1].content;
-                        answerHistory.push([question, { message: response, session_id: sessionId } as ChatAppResponse]);
+                if (session.history) {
+                    for (var i = 0; i < session.history.length; i = i + 2) {
+                        if (i < session.history.length - 1) {
+                            const question = '' + session.history[i].content;
+                            const response = '' + session.history[i + 1].content;
+                            answerHistory.push([question, { message: response, session_id: sessionId } as ChatAppResponse]);
+                        }
                     }
                 }
 

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -240,14 +240,16 @@ const Chat = () => {
                             <i>No chat history yet.</i>
                         )}
                         {sessions && sessions.map((session) => (
-                            <li key={session.session_id}>
+                            session.session_id !== "1234" && (
+                                <li key={session.session_id}>
                                 {session.session_id !== sessionId ? (
-                                <a href="#" onClick={() => { setSessionId(session.session_id) }}>{session.title}</a>
+                                    <a href="#" onClick={() => setSessionId(session.session_id)}>{session.title}</a>
                                 ) : (
-                                <span>{session.title}</span>
+                                    <span>{session.title}</span>
                                 )}
-                            </li>
-                        ))}
+                                </li>
+                            )
+                            ))}
                     </ul>
                 </div>
                 )}


### PR DESCRIPTION
This PR adds support for chat session history. It also remains backwards compatible with API's that don't support the necessary methods for chat session history functionality, so that older labs built for this Front End UI will still function as expected.